### PR TITLE
64-bit Windows API compatibility

### DIFF
--- a/GetRIData.cpp
+++ b/GetRIData.cpp
@@ -250,6 +250,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 	hDisplayBox = CreateWindow(_T("EDIT"), _T(""), WS_CHILD | WS_VISIBLE | ES_LEFT | ES_AUTOHSCROLL | ES_AUTOVSCROLL | ES_READONLY | ES_MULTILINE, 0, 0, 700, 300, hWnd, NULL, hInst, 0);
 	UpdateWindowText();
 	fOldDisplayWndProc = (WNDPROC)SetWindowLong(hDisplayBox, GWL_WNDPROC, (LONG)TextBoxWndProc);
+	fOldDisplayWndProc = (WNDPROC)SetWindowLongPtr(hDisplayBox, GWLP_WNDPROC, (LONG_PTR)TextBoxWndProc);
 	ShowWindow(hWnd, nCmdShow);
 	RegRawInput(hWnd);
 


### PR DESCRIPTION
Hi, this allows compilation by 64-bit toolchain.
> Note  To write code that is compatible with both 32-bit and 64-bit versions of Windows, use SetWindowLongPtr. When compiling for 32-bit Windows, SetWindowLongPtr is defined as a call to the SetWindowLong function.

https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowlongptra
Tested with w64devkit.